### PR TITLE
Bundle jsondiffpatch and remove chalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,35 +32,6 @@ applyDevTools(view)
 
 ### [Code sandbox](https://codesandbox.io/s/summer-cookies-v4ck6)
 
-<details>
-  <summary>About bundling and possible errors (with Vite/Rollup etc)</summary>
-
-\
-There is no longer a dependency to `prosemirror-state` but I did not find a way to extract `DOMSerializer` from `prosemirror-model` without directly importing it. In total I was able to reduce the packages from ~13 to 4. And most importantly the installed `node_modules` can no longer reach sizes of 200 MBs.
-
-If you have a really smart bundler and you are trying to build your editor with dev-toolkit included, you might receive errors regarding its two outdated dependencies `html` and `jsondiffpatch`. `html` should be reasonably easy to import as CommonJS module but for `jsondiffpatch`, however, you might have to set its Node.js-only dependency `chalk` as an external import eg:
-
-svelte.config.js
-```js
-export default {
-  kit: {
-    vite: {
-      build: {
-        rollupOptions: {
-          external: ['chalk']
-        }
-      },
-      define: {
-        'process.env': process.env,
-      },
-    }
-  }
-}
-```
-
-`jsondiffpatch` can be used in both browser and Node.js and it offers some special terminal magic using `chalk` (with a very outdated version) that we are not using and therefore it can be excluded from the bundle. Additionally, it uses `process.env` which you might have to also polyfill. The `dist` folder contains `bundle.umd.min.js` that serves as a stand-alone version with all the dependencies included.
-
-</details>
 
 # API
 

--- a/core/package.json
+++ b/core/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-svelte3": "^3.2.1",
     "jest": "^27.3.1",
     "jest-scss-transform": "^1.0.1",
+    "jsondiffpatch": "^0.4.1",
     "node-sass": "^6.0.1",
     "postcss": "^8.3.11",
     "prettier": "^2.4.1",
@@ -93,7 +94,6 @@
   },
   "dependencies": {
     "html": "^1.0.0",
-    "jsondiffpatch": "^0.4.1",
     "prosemirror-model": "^1.15.0",
     "svelte-tree-view": "^1.3.0"
   },

--- a/core/rollup.config.js
+++ b/core/rollup.config.js
@@ -73,13 +73,19 @@ const defaultBundles = {
     {
       file: pkg.main,
       format: 'cjs',
-      sourcemap: isProduction
+      sourcemap: isProduction,
+      paths: {
+        chalk: './empty.cjs'
+      }
     },
     {
       file: pkg.module,
       format: 'es',
-      sourcemap: isProduction
-    },
+      sourcemap: isProduction,
+      paths: {
+        chalk: './empty'
+      }
+    }
   ],
   external: [
     // TODO: It seems svelte-tree-view must be bundled together with the dev-toolkit otherwise the React app
@@ -103,12 +109,32 @@ const umdBundle = {
       file: './dist/bundle.umd.min.js',
       format: 'umd',
       name: 'prosemirror-dev-toolkit',
-    },
+      paths: {
+        chalk: './empty'
+      },
+      globals: { chalk: 'chalk' }
+    }
   ],
-  external: [
-    'chalk'
-  ],
-  plugins: [...plugins, terser()],
+  external: ['chalk'],
+  plugins: [...plugins, terser()]
 }
 
-export default createBundle ? umdBundle : defaultBundles
+const emptyBundles = {
+  input: 'src/empty.ts',
+  output: [
+    {
+      file: 'dist/empty.cjs',
+      format: 'cjs',
+      exports: 'default',
+      sourcemap: isProduction
+    },
+    {
+      file: 'dist/empty.js',
+      format: 'es',
+      exports: 'default',
+      sourcemap: isProduction
+    }
+  ]
+}
+
+export default createBundle ? umdBundle : [defaultBundles, emptyBundles]

--- a/core/src/empty.ts
+++ b/core/src/empty.ts
@@ -1,0 +1,3 @@
+// empty export to remove `chalk` from `jsondiffpatch` during bundling.
+
+export default null


### PR DESCRIPTION
Bundles `jsondiffpatch` into `prosemirror-dev-toolkit` and removed `chalk` requirement from the bundled output. This frees us from configuring bundlers when using `prosemirror-dev-toolkit`. That's also why I removed related topic in README. 

`jsondiffpatch` itself has a browser-friendly UMD version, which doesn't need `chalk`. I used the same tech from `jsondiffpatch` to remove `chalk` from the bundle files. 