### PR TITLE
fix: include extension to the import

### DIFF
--- a/core/rollup.config.js
+++ b/core/rollup.config.js
@@ -83,7 +83,7 @@ const defaultBundles = {
       format: 'es',
       sourcemap: isProduction,
       paths: {
-        chalk: './empty'
+        chalk: './empty.js'
       }
     }
   ],


### PR DESCRIPTION
Got the following error when I use version 0.0.9:

```
[success] [webpackbar] Client: Compiled with some errors in 6.18m


Module not found: Error: Can't resolve './empty' in '/home/runner/work/remirror/remirror/node_modules/.pnpm/prosemirror-dev-toolkit@0.0.9/node_modules/prosemirror-dev-toolkit/dist'
Did you mean 'empty.js'?
BREAKING CHANGE: The request './empty' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
Client bundle compiled with errors therefore further build is impossible. 
```

Seems that we need to use `from 'empty.js'` instead of `from 'empty'` in `dist/index.js`. The error above is gone after I made this change.