### PR TITLE
fix: don't call applyTransaction before dispatch

### DIFF
--- a/core/src/history-and-diff/SubscriptionPlugin.ts
+++ b/core/src/history-and-diff/SubscriptionPlugin.ts
@@ -45,7 +45,6 @@ export function isSubscriptionPlugin(plugin: Plugin): boolean {
  * Directly remove the subscription plugin into the editor state.
  *
  * This is a hack since EditorState should be treated as immutable normally.
- * @param state
  */
 export function removeSubscriptionPlugin(state: EditorState) {
   for (let i = 0; i < state.plugins.length; i++) {

--- a/core/src/history-and-diff/SubscriptionPlugin.ts
+++ b/core/src/history-and-diff/SubscriptionPlugin.ts
@@ -1,0 +1,66 @@
+import type { EditorState, Transaction } from "prosemirror-state";
+import { Plugin, PluginKey } from "prosemirror-state";
+
+const key = new PluginKey("prosemirror-dev-toolkit-transaction-subscription");
+
+class SubscriptionState {
+  private trs: Transaction[] = [];
+
+  constructor() {
+    this.trs = [];
+  }
+
+  push(tr: Transaction) {
+    this.trs.push(tr);
+  }
+
+  clear() {
+    const trs = this.trs;
+    this.trs = [];
+    return trs;
+  }
+}
+
+type SubscriptionPlugin = Plugin<SubscriptionState>
+
+export function initSubscriptionPlugin(): [SubscriptionPlugin, SubscriptionState] {
+  const pluginState = new SubscriptionState();
+
+  const plugin = new Plugin<SubscriptionState>({
+    key,
+    filterTransaction: tr => {
+      pluginState.push(tr);
+      return true;
+    }
+  });
+
+  return [plugin, pluginState]
+}
+
+export function isSubscriptionPlugin(plugin: Plugin): boolean {
+  return plugin.spec.key === key;
+}
+
+/**
+ * Directly remove the subscription plugin into the editor state.
+ *
+ * This is a hack since EditorState should be treated as immutable normally.
+ * @param state
+ */
+export function removeSubscriptionPlugin(state: EditorState) {
+  for (let i = 0; i < state.plugins.length; i++) {
+    if (isSubscriptionPlugin(state.plugins[i])) {
+      state.plugins.splice(i, 1);
+    }
+  }
+}
+
+/**
+ * Directly insert the subscription plugin into the editor state.
+ *
+ * This is a hack since EditorState should be treated as immutable normally.
+ */
+export function insertSubscriptionPlugin(state: EditorState, plugin: SubscriptionPlugin) {
+  removeSubscriptionPlugin(state);
+  state.plugins.push(plugin);
+}

--- a/core/src/history-and-diff/subscribeToTransactions.ts
+++ b/core/src/history-and-diff/subscribeToTransactions.ts
@@ -1,23 +1,36 @@
-import type { EditorView } from 'prosemirror-view'
-import type { Transaction } from 'prosemirror-state'
+import type { Transaction } from "prosemirror-state"
+import type { EditorView } from "prosemirror-view"
+import {
+  initSubscriptionPlugin,
+  insertSubscriptionPlugin,
+  removeSubscriptionPlugin
+} from "./SubscriptionPlugin"
 
-import { appendNewHistoryEntry } from '$stores/stateHistory'
+import { appendNewHistoryEntry } from "$stores/stateHistory"
 
 let active = false,
   resetDispatch: (() => void) | undefined = undefined
 
 export function subscribeToDispatchTransaction(view: EditorView) {
   active = true
-  const oldDispatchFn = view.someProp('dispatchTransaction')?.bind(view)
+  const oldDispatchFn = view.someProp("dispatchTransaction")?.bind(view)
+  const [plugin, pluginState] = initSubscriptionPlugin()
+
   view.setProps({
-    dispatchTransaction(tr: Transaction) {
+    dispatchTransaction: (tr: Transaction) => {
+      insertSubscriptionPlugin(view.state, plugin)
+
       const stateBeforeDispatch = view.state
-      const { state, transactions } = this.state.applyTransaction(tr)
+
       if (oldDispatchFn) {
         oldDispatchFn(tr)
       } else {
-        this.updateState(state)
+        view.updateState(view.state.apply(tr))
       }
+
+      const transactions = pluginState.clear()
+      removeSubscriptionPlugin(view.state)
+
       if (active) {
         appendNewHistoryEntry(transactions, view.state, stateBeforeDispatch)
       }


### PR DESCRIPTION
Previously, `prosemirror-dev-toolkit` will call `state.applyTransaction` before call `oldDispatchFn` (if it exists). Since `oldDispatchFn` itself will most likely also trigger `state.applyTransaction`, we will trigger `applyTransaction` twice for the same transaction. This causes some issues because we have a plugin that assumes it can't see a transaction twice. 

This PR fixes the issue above by creating a plugin that will record all transactions during a dispatch. We will extract recorded transactions later after dispatch and pass them to HistoryEntry. By doing that, we can avoid calling `applyTransaction` twice. This is similar to the official [prosemirror-history](https://github.com/ProseMirror/prosemirror-history/blob/a7318c0150023c3142bf81074bcff558380c2d93/src/history.js#L398) plugin. 

I can't directly pass this plugin to `view` by using `view.someProps` because it [doesn't accept a plugin that has state](https://github.com/ocavue/prosemirror-view/blob/037d1982464c1940138e693b3366a9f770d627b9/src/index.js#L468). That's why I have to inject the plugin into `view.state` before dispatch. 